### PR TITLE
Minor fixes for consistency of property names

### DIFF
--- a/data/spells/spellData.json
+++ b/data/spells/spellData.json
@@ -327,7 +327,7 @@
     "castingTime": "action",
     "level": 5,
     "school": "Abjuration",
-    "effect": "The barrier hedges out creatures other than undead and constructs. The barrier lasts for the duration.\nThe barrier prevents an affected creature from passing or reaching through. An affected creature can cast spells or make attacks with ranged or reach weapons through the barrier.\nIf you move so that an affected creature is forced to pass through the barrier, the spell ends.",
+    "effects": "The barrier hedges out creatures other than undead and constructs. The barrier lasts for the duration.\nThe barrier prevents an affected creature from passing or reaching through. An affected creature can cast spells or make attacks with ranged or reach weapons through the barrier.\nIf you move so that an affected creature is forced to pass through the barrier, the spell ends.",
     "classes": [
       "Druid"
     ]
@@ -1099,7 +1099,7 @@
     "castingTime": "action",
     "level": 2,
     "school": "Illusion",
-    "effect": "For the duration of this spell, any creature has disadvantage on attack rolls against you. An attacker is immune to this effect if it doesn't rely on sight.",
+    "effects": "For the duration of this spell, any creature has disadvantage on attack rolls against you. An attacker is immune to this effect if it doesn't rely on sight.",
     "classes": [
       "Druid",
       "Sorcerer",
@@ -1132,7 +1132,7 @@
       "damageType": "bludgeoning",
       "saveFailure": "and restrained. The restrained creature can use an action to make a Strength or Dexterity check (the creature's choice) against the spell's saving throw DC. On a success, the creature is no longer restrained and must either move off the pillar or fall off it."
     },
-    "effect": "You cause up to six pillars of stone to burst from places on the ground that you can see within range. Each pillar is a cylinder that has a diameter of 5 feet and a height of up to 30 feet. The ground where a pillar appears must be wide enough for its diameter, and you can target ground under a creature if that creature is Medium or smaller. Each pillar has AC 5 and 30 hit points. When reduced to 0 hit points, a pillar crumbles into rubble, which creates an area of difficult terrain with a 10-foot radius. The rubble lasts until cleared.\nIf a pillar is created under a creature, that creature must succeed on a Dexterity saving throw or be lifted by the pillar. A creature can choose to fail the save.\nIf a pillar is prevented from reaching its full height because of a ceiling or other obstacle, a creature on the pillar takes damage as outlined above.",
+    "effects": "You cause up to six pillars of stone to burst from places on the ground that you can see within range. Each pillar is a cylinder that has a diameter of 5 feet and a height of up to 30 feet. The ground where a pillar appears must be wide enough for its diameter, and you can target ground under a creature if that creature is Medium or smaller. Each pillar has AC 5 and 30 hit points. When reduced to 0 hit points, a pillar crumbles into rubble, which creates an area of difficult terrain with a 10-foot radius. The rubble lasts until cleared.\nIf a pillar is created under a creature, that creature must succeed on a Dexterity saving throw or be lifted by the pillar. A creature can choose to fail the save.\nIf a pillar is prevented from reaching its full height because of a ceiling or other obstacle, a creature on the pillar takes damage as outlined above.",
     "classes": [
       "Druid"
     ]
@@ -1154,7 +1154,7 @@
     "castingTime": "action",
     "level": 0,
     "school": "Evocation",
-    "effect": "As part of the action used to cast this spell, you must make a melee attack with a weapon against one creature within the spell's range, otherwise the spell fails. On a hit, the target suffers the attack's normal effects, and it becomes sheathed in booming energy until the start of your next turn. If the target willingly moves before then, it immediately takes [[((@{level} + 1) / 6 + 0.5)d8]] thunder damage, and the spell ends.",
+    "effects": "As part of the action used to cast this spell, you must make a melee attack with a weapon against one creature within the spell's range, otherwise the spell fails. On a hit, the target suffers the attack's normal effects, and it becomes sheathed in booming energy until the start of your next turn. If the target willingly moves before then, it immediately takes [[((@{level} + 1) / 6 + 0.5)d8]] thunder damage, and the spell ends.",
     "classes": [
       "Sorcerer",
       "Warlock",
@@ -4913,7 +4913,7 @@
       "secondaryDamage": "(((@{level} + 1) / 6 + 0.5)-1)d8",
       "secondaryDamageType": "fire"
     },
-    "effect": "As part of the action used to cast this spell, you must make a melee attack with a weapon against one creature within the spell's range, otherwise the spell fails. On a hit, the target suffers the attack's normal effects, and green fire leaps from the target to a different creature of your choice that you can see within 5 feet of it. The second creature takes fire damage equal to your spellcasting ability modifier.",
+    "effects": "As part of the action used to cast this spell, you must make a melee attack with a weapon against one creature within the spell's range, otherwise the spell fails. On a hit, the target suffers the attack's normal effects, and green fire leaps from the target to a different creature of your choice that you can see within 5 feet of it. The second creature takes fire damage equal to your spellcasting ability modifier.",
     "classes": [
       "Sorcerer",
       "Warlock",
@@ -6313,7 +6313,7 @@
       "ability": "strength",
       "damage": "((@{level} + 1) / 6 + 0.5)d8",
       "damageType": "lightning",
-      "saveCondition": "if it is within 5 feet of you after being pulled",
+      "condition": "if it is within 5 feet of you after being pulled",
       "saveFailure": "pulled up to 10 feet in a straight line toward you"
     },
     "classes": [
@@ -7634,7 +7634,7 @@
     "emote": "conjures a Large quasi-real, horselike creature",
     "source": "phb 265",
     "range": "30 ft",
-    "targer": "on the ground in an unoccupied space within range",
+    "target": "on the ground in an unoccupied space within range",
     "components": {
       "verbal": true,
       "somatic": true
@@ -8129,7 +8129,7 @@
     "castingTime": "action",
     "level": 1,
     "school": "Abjuration",
-    "effets": "target is protected against certain types of creatures: aberrations, celestials, elementals, fey, fiends, and undead.\nThe protection grants several benefits. Creatures of those types have disadvantage on attack rolls against the target. The target also can't be charmed, frightened, or possessed by them. If the target is already charmed, frightened, or possessed by such a creature, the target has advantage on any new saving throw against the relevant effect.",
+    "effects": "target is protected against certain types of creatures: aberrations, celestials, elementals, fey, fiends, and undead.\nThe protection grants several benefits. Creatures of those types have disadvantage on attack rolls against the target. The target also can't be charmed, frightened, or possessed by them. If the target is already charmed, frightened, or possessed by such a creature, the target has advantage on any new saving throw against the relevant effect.",
     "classes": [
       "Cleric",
       "Paladin",
@@ -8311,7 +8311,7 @@
       "damage": "((@{level} + 1) / 6 + 0.5)d8",
       "damageType": "cold"
     },
-    "effect": "its speed is reduced by 10 feet until the start of your next turn",
+    "effects": "its speed is reduced by 10 feet until the start of your next turn",
     "classes": [
       "Sorcerer",
       "Wizard"
@@ -8611,7 +8611,7 @@
     "emote": "creates 3 rays of fire and hurls them at targets",
     "source": "phb 273",
     "range": "120 ft",
-    "targets": "you can hurl the 3 rays at one target or several - make a ranged spell attack for each ray",
+    "target": "you can hurl the 3 rays at one target or several - make a ranged spell attack for each ray",
     "components": {
       "verbal": true,
       "somatic": true
@@ -8830,7 +8830,7 @@
     "castingTime": "action",
     "level": 0,
     "school": "Transmutation",
-    "effect": "You manipulate the target in one of the following ways:\n- You instantaneously move or otherwise change the flow of the water as you direct, up to 5 feet in any direction. This movement doesn't have enough force to cause damage.\n- You cause the water to form into simple shapes and animate at your direction. This change lasts for 1 hour.\n- You change the water's color or opacity. The water must be changed in the same way throughout. This change lasts for 1 hour.\n- You freeze the water, provided that there are no creatures in it. The water unfreezes in 1 hour. If you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.",
+    "effects": "You manipulate the target in one of the following ways:\n- You instantaneously move or otherwise change the flow of the water as you direct, up to 5 feet in any direction. This movement doesn't have enough force to cause damage.\n- You cause the water to form into simple shapes and animate at your direction. This change lasts for 1 hour.\n- You change the water's color or opacity. The water must be changed in the same way throughout. This change lasts for 1 hour.\n- You freeze the water, provided that there are no creatures in it. The water unfreezes in 1 hour. If you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.",
     "classes": [
       "Druid",
       "Sorcerer",
@@ -11008,7 +11008,7 @@
     "castingTime": "action",
     "level": 9,
     "school": "Conjuration",
-    "effect": "Desire is the most powerful spell a deadly creature can throw. Simply by speaking aloud, you can alter the very foundations of reality as you wish.\nThe most basic use of this spell is to duplicate any other out of 8th level or lower. You only need to fill out any conditions for that, not even the need for costly components. The fate simply takes effect. You can also create one of the following effects of your choice:\n- You create one object of up to 25,000 gp in value that isn't a magic item. The object can be no more than 300 feet in any dimension, and it appears in an unoccupied space you can see on the ground.\n- You allow a maximum of twenty creatures you can see to get all their points and you dispel all effects affecting them, as described in greater restoration spell.\n- You grant to a maximum of ten creatures you can see resistance to a damage type you choose.\n- You grant to a maximum of ten creatures you can see immunity to a single spell or other magical effect for 8 hours. For example, you can immunize yourself and your companions against the attack of the Lich draining.\n- You cancel a recent event unique by requiring a new replacement jet diced any jet made during the last round (including your last turn). The reality is transformed to match the new launch. For example, a wish spell can cancel a successful saving throw enemy critical strike an opponent or ally saving throw missed. You can impose a jet with advantage or disadvantage, and you can choose to use the new result of the start or the old.\nYou can also do other things than the above examples. Describe your wishes to your MD in the most accurate way possible. The DM is free to determine what happens in this case; more desire, the more likely it is that something goes wrong. This spell may simply fail, the effect you want might be only partially executed, or you may suffer from unpredictable consequences depending on your formulation wish. For example, want an enemy died could propel you to a future time when your enemy is no longer alive, you effectively eliminating the game. Similarly, desiring a legendary magical object or artifact could carry you instantaneously in the presence of the current owner of the object.\nStress to cast this spell to produce an effect other than the reproduction of another spell weakens you. After undergoing this tension every time you cast a spell, and this until your next extended rest, you suffer 1d10 necrotic damage per spell level. This damage can not be reduced or avoided in any way. In addition, your Force falls to 3, if it is not already less than 3, for 2d4 days. For each day spent resting or practicing a minor activity, your recovery time decreases by 2 days. Finally, you have a 33% chance of never being able to cast the spell if you wish undergoes stress.",
+    "effects": "Desire is the most powerful spell a deadly creature can throw. Simply by speaking aloud, you can alter the very foundations of reality as you wish.\nThe most basic use of this spell is to duplicate any other out of 8th level or lower. You only need to fill out any conditions for that, not even the need for costly components. The fate simply takes effect. You can also create one of the following effects of your choice:\n- You create one object of up to 25,000 gp in value that isn't a magic item. The object can be no more than 300 feet in any dimension, and it appears in an unoccupied space you can see on the ground.\n- You allow a maximum of twenty creatures you can see to get all their points and you dispel all effects affecting them, as described in greater restoration spell.\n- You grant to a maximum of ten creatures you can see resistance to a damage type you choose.\n- You grant to a maximum of ten creatures you can see immunity to a single spell or other magical effect for 8 hours. For example, you can immunize yourself and your companions against the attack of the Lich draining.\n- You cancel a recent event unique by requiring a new replacement jet diced any jet made during the last round (including your last turn). The reality is transformed to match the new launch. For example, a wish spell can cancel a successful saving throw enemy critical strike an opponent or ally saving throw missed. You can impose a jet with advantage or disadvantage, and you can choose to use the new result of the start or the old.\nYou can also do other things than the above examples. Describe your wishes to your MD in the most accurate way possible. The DM is free to determine what happens in this case; more desire, the more likely it is that something goes wrong. This spell may simply fail, the effect you want might be only partially executed, or you may suffer from unpredictable consequences depending on your formulation wish. For example, want an enemy died could propel you to a future time when your enemy is no longer alive, you effectively eliminating the game. Similarly, desiring a legendary magical object or artifact could carry you instantaneously in the presence of the current owner of the object.\nStress to cast this spell to produce an effect other than the reproduction of another spell weakens you. After undergoing this tension every time you cast a spell, and this until your next extended rest, you suffer 1d10 necrotic damage per spell level. This damage can not be reduced or avoided in any way. In addition, your Force falls to 3, if it is not already less than 3, for 2d4 days. For each day spent resting or practicing a minor activity, your recovery time decreases by 2 days. Finally, you have a 33% chance of never being able to cast the spell if you wish undergoes stress.",
     "classes": [
       "Sorcerer",
       "Wizard"
@@ -11039,7 +11039,7 @@
       "higherLevelDice": "1",
       "higherLevelDie": "d12"
     },
-    "effect": "on each of your turns for the duration, you can use your action to deal 1d12 lightning damage to the target automatically. The spell ends if you use your action to do anything else. The spell also ends if the target is ever outside the spell's range or if it has total cover from you.",
+    "effects": "on each of your turns for the duration, you can use your action to deal 1d12 lightning damage to the target automatically. The spell ends if you use your action to do anything else. The spell also ends if the target is ever outside the spell's range or if it has total cover from you.",
     "classes": [
       "Sorcerer",
       "Warlock",


### PR DESCRIPTION
Wanted to get this updated on your repo before i forget - going to have to delete it from my one before submitting to roll20 - I've just made all the JSON properties consistent between spells. The converter moans about unknown properties to avoid confusing surprises.
