### PR TITLE
Fixed Iron Golem breath damage

### DIFF
--- a/data/monsters/MonsterManual.json
+++ b/data/monsters/MonsterManual.json
@@ -11109,7 +11109,7 @@
       },
       {
         "name": "Poison Breath",
-        "text": "The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 45 (l0d8) poison damage on a failed save, or half as much damage on a successful one.",
+        "text": "The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one.",
         "recharge": "Recharge 5-6"
       }
     ]


### PR DESCRIPTION
Found a small OCR error in the iron golem's breath damage. Fixed.
